### PR TITLE
Fixing markdown

### DIFF
--- a/logstash/README.md
+++ b/logstash/README.md
@@ -3,27 +3,27 @@
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 It is a simple wrapper of the [Ruby Zeus Client](https://github.com/CiscoZeus/ruby-zeusclient).
 
-##Developing
+## Developing
 
 First of all you'll need JRuby, since Logstash is written in ruby and runs on the JVM.
 You can get it [in their website](http://jruby.org/download) or through [RVM](https://rvm.io/).
 
-###Building
+### Building
 
 ```sh
 jruby -S bundle install
 jruby -S gem build logstash-output-CiscoZeus.gemspec
 ```
 
-##Usage
+## Usage
 
-###Installation
+### Installation
 
 ```sh
 logstash-plugin install logstash-output-CiscoZeus-0.1.0.gem
 ```
 
-###Configuration
+### Configuration
 
 Add this configuration to the output section of your logstash configuration file.
 
@@ -37,7 +37,8 @@ output {
 }
 ```
 
-##License and copyright
+## License and copyright
+
 Copyright(C) 2017 - Cisco Systems, Inc.
 Apache License, Version 2.0
 


### PR DESCRIPTION
Today github modified their markdown rendering:
https://githubengineering.com/a-formal-spec-for-github-markdown/

This changes make logstash plugin adapt to this new specification. 